### PR TITLE
Fixed installation errors in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ endif
 
 
 initdb:
-	@createuser -d -w postgres
-	@createdb -Opostgres -Eutf8 blog
-	@psql -U postgres -d blog -f db.sql
+	@sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || createuser -d -w postgres
+	@sudo -u postgres psql -lqt | cut -d \| -f 1 | grep -wq blog || createdb -Opostgres -Eutf8 blog
+	@sudo -u postgres psql -U postgres -d blog -f db.sql
 
 
 watch:

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ UNAME_S := $(shell uname -s)
 bootstrap:
 ifeq "$(UNAME_S)" "Darwin"
 	brew tap zewo/tap
-	brew install libvenice postgresql
+	brew install libvenice postgresql uri_parser http_parser
 else
 	sudo add-apt-repository 'deb [trusted=yes] http://apt.zewo.io/deb ./'
 	sudo apt-get install libvenice postgresql
+	sudo git clone https://github.com/Zewo/uri_parser.git && cd uri_parser && sudo make && sudo make package && sudo dpkg -i uri_parser.deb && cd .. && sudo rm -rf ./uri_parser
+	sudo git clone https://github.com/Zewo/http_parser.git && cd http_parser && sudo make && sudo make package && sudo dpkg -i http_parser.deb && cd .. && sudo rm -rf ./http_parser
+
 endif
 	pip install watchdog --upgrade
 
@@ -38,6 +41,7 @@ stop:
 
 clean:
 	@rm -rf ./Packages
+	@sudo rm -rf ./uri_parser ./http_parser
 
 
 build:

--- a/Package.swift
+++ b/Package.swift
@@ -10,5 +10,6 @@ let package = Package(
         .Package(url: "https://github.com/Zewo/CLibvenice.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/Zewo/CHTTPParser.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/kylef/Commander.git", majorVersion: 0, minor: 4),
+		.Package(url: "https://github.com/Zewo/Sideburns.git", majorVersion: 0, minor: 1)
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,6 @@ let package = Package(
         .Package(url: "https://github.com/Zewo/CLibvenice.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/Zewo/CHTTPParser.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/kylef/Commander.git", majorVersion: 0, minor: 4),
-		.Package(url: "https://github.com/Zewo/Sideburns.git", majorVersion: 0, minor: 1)
+        .Package(url: "https://github.com/Zewo/Sideburns.git", majorVersion: 0, minor: 1)
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
         .Package(url: "https://github.com/Zewo/CURIParser.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/Zewo/CLibvenice.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/Zewo/CHTTPParser.git", majorVersion: 0, minor: 1),
-        .Package(url: "https://github.com/kylef/Commander.git", majorVersion: 0, minor: 4),
-        .Package(url: "https://github.com/Zewo/Sideburns.git", majorVersion: 0, minor: 1)
+        .Package(url: "https://github.com/kylef/Commander.git", majorVersion: 0, minor: 4)
     ]
 )

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -1,7 +1,6 @@
 import HTTP
 import Router
 import Middleware
-import Sideburns
 
 let router = Router { r in
 


### PR DESCRIPTION
`make` is failed on Ubuntu 14.04.

Fixed:
- `make bootstrap`: `uri_parser` and `http_parser` dependencies are added
- `make initdb`: checks whether user and db is existed before creating 